### PR TITLE
Terraform config generalization and typo fixes

### DIFF
--- a/iac/aws/batch/modules/networking/main.tf
+++ b/iac/aws/batch/modules/networking/main.tf
@@ -1,0 +1,4 @@
+resource "aws_db_subnet_group" "hydradb_sg" {
+  name        = var.rds_subnet_group_name
+  subnet_ids  = var.rds_subnets
+}

--- a/iac/aws/batch/modules/networking/variables.tf
+++ b/iac/aws/batch/modules/networking/variables.tf
@@ -1,0 +1,9 @@
+variable "rds_subnet_group_name" {
+  description = "RDS subnet group name"
+  type        = string
+}
+
+variable "rds_subnets" {
+  description = "Subnets attached to RDS"
+  type        = list(string)
+}

--- a/iac/aws/batch/modules/permissions/main.tf
+++ b/iac/aws/batch/modules/permissions/main.tf
@@ -1,0 +1,27 @@
+
+resource "aws_security_group" "hydrabatch_sg" {
+  name    = var.hydrabatch_sg
+  vpc_id  = var.vpc_id
+
+  ingress {
+    from_port         = 0
+    to_port           = 3306
+    protocol          = "tcp"
+    cidr_blocks       = var.cidr_blocks
+  }
+
+  ingress {
+    from_port         = 0
+    to_port           = 0
+    protocol          = "-1"
+    self              = true
+  }
+
+  egress {
+    from_port         = 0
+    to_port           = 0
+    protocol          = "-1"
+    cidr_blocks       = ["0.0.0.0/0"]
+    ipv6_cidr_blocks  = ["::/0"]
+  }
+}

--- a/iac/aws/batch/modules/permissions/outputs.tf
+++ b/iac/aws/batch/modules/permissions/outputs.tf
@@ -1,0 +1,5 @@
+output "hydrabatch_sg_id" {
+  value       = aws_security_group.hydrabatch_sg.id
+  description = "Security group ID"
+}
+

--- a/iac/aws/batch/modules/permissions/variables.tf
+++ b/iac/aws/batch/modules/permissions/variables.tf
@@ -1,0 +1,15 @@
+
+variable "hydrabatch_sg" {
+  description = "Security group name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC id"
+  type        = string
+}
+
+variable "cidr_blocks" {
+  description = "List of CIDR blocks to allow ingress access"
+  type        = list(string)
+}

--- a/iac/aws/batch/table_setup.sql
+++ b/iac/aws/batch/table_setup.sql
@@ -1,6 +1,6 @@
--- DROP DATABASE ailab_tracker;
-CREATE DATABASE IF NOT EXISTS <ENTER DATABASE HERE>;
-USE <ENTER DATABASE HERE>;
+-- DROP DATABASE hydra_tracker;
+CREATE DATABASE IF NOT EXISTS hydra_tracker;
+USE hydra_tracker;
 
 DROP TABLE IF EXISTS schema_info;
 CREATE TABLE schema_info (

--- a/iac/aws/batch/variables.tf
+++ b/iac/aws/batch/variables.tf
@@ -3,6 +3,26 @@ variable "aws_region" {
   type        = string
 }
 
+variable "vpc_id" {
+  description = "VPC id"
+  type        = string
+}
+
+variable "subnet_a" {
+  description = "ID of subnet a"
+  type        = string
+}
+
+variable "subnet_b" {
+  description = "ID of subnet b"
+  type        = string
+}
+
+variable "subnet_c" {
+  description = "ID of subnet c"
+  type        = string
+}
+
 variable "password_random_length" {
   description = "Number of randomly generated characters in password"
   type = number
@@ -33,8 +53,24 @@ variable "username_secret_name" {
   type = string
 }
 
+variable "hydrabatch_sg" {
+  description = "Security group name"
+  type        = string
+}
+
+variable "sg_cidr_blocks" {
+  description = "CIDR Blocks to allow ingress access to required ports of security group"
+  type        = list(string)
+}
+
+# networking
+variable "rds_subnet_group_name" {
+  description = "RDB subnet group name"
+  type        = string
+}
+
 variable "batch_backend_store_identifier" {
-  description = "RDS Database identifier of MLflow backend store"
+  description = "RDS Database identifier of batch backend store"
   type        = string
 }
 
@@ -72,14 +108,15 @@ variable "skip_final_snapshot" {
   default     = true
 }
 
+variable "db_publicly_accessible" {
+  description = "Database should have a public facing IP"
+  type        = bool
+  default     = true
+}
+
 variable "db_subnet_group_name" {
   description = "Database subnet group name"
   type        = string
-}
-
-variable "vpc_security_groups" {
-  description = "VPC security groups associated with database"
-  type        = list(string)
 }
 
 variable "compute_environments" {

--- a/iac/aws/mlflow/main.tf
+++ b/iac/aws/mlflow/main.tf
@@ -1,13 +1,7 @@
 terraform {
   required_version = ">= 0.14"
 
-  backend "s3" {
-    bucket          = ""
-    key             = ""
-    encrypt         = true
-    region          = ""
-    dynamodb_table  = ""
-  }
+  backend "s3" {}
 
   required_providers {
     aws = {
@@ -39,7 +33,7 @@ module "permissions" {
 module "networking" {
   source                = "./modules/networking"
   rds_subnet_group_name = var.rds_subnet_group_name
-  rds_subnets           = [var.subnet_a, var.subnet_b]
+  rds_subnets           = [var.subnet_a, var.subnet_b, var.subnet_c]
 }
 
 module "secrets" {
@@ -56,7 +50,7 @@ module "load_balancing" {
   source              = "./modules/load_balancing"
   lb_name             = var.lb_name
   lb_security_groups  = [module.permissions.mlflow_sg_id]
-  lb_subnets          = [var.subnet_a, var.subnet_b]
+  lb_subnets          = [var.subnet_a, var.subnet_b, var.subnet_c]
   lb_target_group     = var.lb_target_group
   vpc_id              = var.vpc_id
 }
@@ -91,7 +85,7 @@ module "task_deployment" {
   docker_image                = "${module.container_repository.container_repository_url}:latest"
   ecs_service_name            = var.ecs_service_name
   ecs_service_security_groups = [module.permissions.mlflow_sg_id]
-  ecs_service_subnets         = [var.subnet_a]
+  ecs_service_subnets         = [var.subnet_a, var.subnet_b, var.subnet_c]
   execution_role_arn          = module.permissions.mlflow_ecs_tasks_role_arn
   mlflow_ecs_task_family      = var.mlflow_ecs_task_family
   mlflow_server_cluster       = var.mlflow_server_cluster

--- a/iac/aws/mlflow/modules/task_deployment/main.tf
+++ b/iac/aws/mlflow/modules/task_deployment/main.tf
@@ -89,4 +89,9 @@ resource "aws_ecs_service" "service" {
     security_groups   = var.ecs_service_security_groups
     assign_public_ip  = true
   }
+
+  # Allow external changes without Terraform plan difference
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
 }

--- a/iac/aws/mlflow/variables.tf
+++ b/iac/aws/mlflow/variables.tf
@@ -18,6 +18,11 @@ variable "subnet_b" {
   type        = string
 }
 
+variable "subnet_c" {
+  description = "ID of subnet c"
+  type        = string
+}
+
 # container_repository
 variable "mlflow_container_repository" {
   description = "Container repository name"


### PR DESCRIPTION
Before merging we have to decide if this is a conflict with the SQL work to do the DB setup via lambda.

The main scope is to allow better configuration of the S3 variables for mlflow and batch. 

With this the user would do the inits like this: 

```
terraform init -backend-config=/opt/hydra-conf/terraform-mlflow-back-end.cfg
terraform init -backend-config=/opt/hydra-conf/batch-terraform-back-end.cfg
```
The contents of the files are basically the variables that used to be in the main tf files. `batch-terraform-back-end.cfg` looks like this:
```
bucket = "user-bucket-name-for-terraform-storage"
key = "hydra-batch"
encrypt = true
region = "us-west-2"
dynamodb_table = "terraform_state_lock"
```

The configuration files can be stored in a private repo at the organization level without interfering with the public hydra development.

The batch RDS is now also mimicking the mlflow setup. This should allow better consistency.

The private/public setting for the RDS has been moved to a configuration variable as well.

Also fixed a typo in the terraform variable descriptions.